### PR TITLE
lighthouse: add heartbeats

### DIFF
--- a/proto/torchft.proto
+++ b/proto/torchft.proto
@@ -53,8 +53,15 @@ message LighthouseQuorumResponse {
     Quorum quorum = 1;
 }
 
+message LighthouseHeartbeatRequest {
+    string replica_id = 1;
+}
+
+message LighthouseHeartbeatResponse {}
+
 service LighthouseService {
     rpc Quorum (LighthouseQuorumRequest) returns (LighthouseQuorumResponse);
+    rpc Heartbeat (LighthouseHeartbeatRequest) returns (LighthouseHeartbeatResponse);
 }
 
 message ManagerQuorumRequest {


### PR DESCRIPTION
This adds heartbeats to the lighthouse from the manager. These run every 100ms and are intended to allow the lighthouse to very quickly identify which workers are live vs not and to eliminate the join window.

Test plan:

```
cargo test
```
run lightouse+2 train_ddp replicas