### PR TITLE
lighthouse: add dashboard

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0.89"
+askama = "0.12.1"
+axum = "0.7.7"
+gethostname = "0.5.0"
 log = "0.4.22"
 prost = "0.13.3"
 pyo3 = {version="0.22.3", features = ["extension-module"]}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,57 @@
+<head>
+  <title>Lighthouse Dashboard - torchft</title>
+  <link rel="shortcut icon" type="image/x-icon" href="https://pytorch.org/favicon.ico?">
+  <style>
+  body {
+    margin: 0;
+    font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",Arial,"Noto Sans",sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol","Noto Color Emoji";
+    font-size: 1rem;
+    font-weight: 400;
+    line-height: 1.5;
+    color: #212529;
+    text-align: left;
+    background-color: #fff;
+  }
+  h1, h2, h3, h4, h5, h6, .h1, .h2, .h3, .h4, .h5, .h6 {
+    margin-bottom: .5rem;
+    font-weight: 500;
+    line-height: 1.2;
+  }
+  header {
+    background-color: rgba(0, 0, 0, 0.17);
+    padding: 10px;
+    display: flex;
+    align-items: center;
+    padding: 16px;
+    justify-content: space-between;
+  }
+  header h1 {
+    display: inline-block;
+    margin: 0;
+  }
+  section {
+    max-width: 1280px;
+    padding: 16px;
+    margin: 0 auto;
+  }
+  .member {
+    display: inline-block;
+    margin: 10px;
+    padding: 10px;
+    border: 1px solid #333;
+  }
+  .hearbeat.old {
+    color: red;
+  }
+  </style>
+  <script src="https://unpkg.com/htmx.org@2.0.3"></script>
+</head>
+
+<header>
+  <h1>Lighthouse Dashboard - torchft</h1>
+  <img src="https://pytorch.org/assets/images/logo.svg" width="128"/>
+</header>
+
+<section hx-get="/status" hx-trigger="load, every 1s">
+  Loading...
+</section>

--- a/templates/status.html
+++ b/templates/status.html
@@ -1,0 +1,38 @@
+<h2>Quorum Status</h2>
+
+Current quorum_id: {{quorum_id}}
+
+<h3>Previous Quorum</h3>
+{% if let Some(prev_quorum) = prev_quorum %}
+
+Previous quorum id: {{prev_quorum.quorum_id}}
+
+<div>
+{% for member in prev_quorum.participants %}
+
+<div class="member">
+  <b>{{ member.replica_id }}</b> <br/>
+  Step: {{ member.step }} <br/>
+  Manager: {{ member.address }} <br/>
+  TCPStore: {{ member.store_address }}
+</div>
+
+{% endfor %}
+</div>
+
+{% endif %}
+
+<h3>Heartbeats</h3>
+
+<ul>
+{% for replica_id in heartbeats.keys() %}
+
+  {% let age = heartbeats[replica_id].elapsed().as_secs_f64() %}
+  <li class="heartbeat">
+    {{ replica_id }}: seen {{ age }}s ago
+  </li>
+
+{% endfor %}
+</ul>
+
+


### PR DESCRIPTION
This adds a dashboard to the lighthouse server.

![20241106_22h41m00s_grim](https://github.com/user-attachments/assets/034d1b3f-2320-4b28-a4d9-114c022dd6d3)


Test plan:

Start lighthouse and run two train_ddp workers

lint+test.sh