### PR TITLE
lighthosue, manager: dashboard kill and heartbeat old ui

### DIFF
--- a/proto/torchft.proto
+++ b/proto/torchft.proto
@@ -98,8 +98,14 @@ message ShouldCommitResponse {
     bool should_commit = 1;
 }
 
+message KillRequest {
+    string msg = 1;
+}
+message KillResponse {}
+
 service ManagerService {
     rpc Quorum (ManagerQuorumRequest) returns (ManagerQuorumResponse);
     rpc CheckpointAddress(CheckpointAddressRequest) returns (CheckpointAddressResponse);
     rpc ShouldCommit(ShouldCommitRequest) returns (ShouldCommitResponse);
+    rpc Kill(KillRequest) returns (KillResponse);
 }

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -23,9 +23,9 @@ use crate::torchftpb::lighthouse_service_client::LighthouseServiceClient;
 use crate::torchftpb::manager_service_client::ManagerServiceClient;
 use crate::torchftpb::{
     manager_service_server::{ManagerService, ManagerServiceServer},
-    CheckpointAddressRequest, CheckpointAddressResponse, LighthouseHeartbeatRequest,
-    LighthouseQuorumRequest, ManagerQuorumRequest, ManagerQuorumResponse, Quorum, QuorumMember,
-    ShouldCommitRequest, ShouldCommitResponse,
+    CheckpointAddressRequest, CheckpointAddressResponse, KillRequest, KillResponse,
+    LighthouseHeartbeatRequest, LighthouseQuorumRequest, ManagerQuorumRequest,
+    ManagerQuorumResponse, Quorum, QuorumMember, ShouldCommitRequest, ShouldCommitResponse,
 };
 
 #[cfg(not(test))]
@@ -131,7 +131,7 @@ impl Manager {
                 replica_id: self.replica_id.clone(),
             });
 
-            let response = client.heartbeat(request).await;
+            let _response = client.heartbeat(request).await;
 
             sleep(Duration::from_millis(100)).await;
         }
@@ -333,12 +333,17 @@ impl ManagerService for Arc<Manager> {
         };
         Ok(Response::new(reply))
     }
+
+    async fn kill(&self, request: Request<KillRequest>) -> Result<Response<KillResponse>, Status> {
+        let req = request.into_inner();
+
+        warn!("got kill request: {}", req.msg);
+        std::process::exit(1);
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use tokio::time::sleep;
-
     use super::*;
 
     async fn should_commit(rank: i64, should_commit: bool) -> Result<ShouldCommitResponse> {

--- a/templates/index.html
+++ b/templates/index.html
@@ -40,7 +40,7 @@
     padding: 10px;
     border: 1px solid #333;
   }
-  .hearbeat.old {
+  .heartbeat.old {
     color: red;
   }
   </style>

--- a/templates/status.html
+++ b/templates/status.html
@@ -15,6 +15,11 @@ Previous quorum id: {{prev_quorum.quorum_id}}
   Step: {{ member.step }} <br/>
   Manager: {{ member.address }} <br/>
   TCPStore: {{ member.store_address }}
+
+  <button hx-post="/replica/{{member.replica_id}}/kill"
+          hx-trigger="click">
+    Kill
+  </button>
 </div>
 
 {% endfor %}
@@ -28,7 +33,7 @@ Previous quorum id: {{prev_quorum.quorum_id}}
 {% for replica_id in heartbeats.keys() %}
 
   {% let age = heartbeats[replica_id].elapsed().as_secs_f64() %}
-  <li class="heartbeat">
+  <li class="heartbeat {% if heartbeats[replica_id].lt(old_age_threshold) %}old{%endif%}">
     {{ replica_id }}: seen {{ age }}s ago
   </li>
 


### PR DESCRIPTION
This adds a kill button to the dashboard.

It also will highlight when heartbeats have stopped.

Test plan:

run lighthouse + 1 train_ddp worker

cargo fmt, cargo test

![20241108_23h04m21s_grim](https://github.com/user-attachments/assets/0a5bbaf4-a73a-4264-90c5-5aa6e576f410)
