### PR TITLE
ci: use stable rust and gate on number of gpus

### DIFF
--- a/.github/workflows/unittest.yaml
+++ b/.github/workflows/unittest.yaml
@@ -25,12 +25,17 @@ jobs:
       gpu-arch-type: ${{ matrix.gpu-arch-type }}
       gpu-arch-version: ${{ matrix.gpu-arch-version }}
       script: |
+        set -ex
+
+        # install python and protobuf
         conda create -n venv python=3.10 protobuf -y
         conda activate venv
-
-        yum install -y rust cargo
-
         python -m pip install --upgrade pip
+
+        # install recent version of Rust via rustup
+        curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain=stable --profile=default -y
+        . "$HOME/.cargo/env"
+
         pip install -e .[dev] -v
 
         pytest -v

--- a/torchft/process_group_test.py
+++ b/torchft/process_group_test.py
@@ -110,8 +110,8 @@ class ProcessGroupTest(TestCase):
         m = torch.nn.parallel.DistributedDataParallel(m, process_group=pg)
         m(torch.rand(2, 3))
 
-    @skipUnless(torch.cuda.is_available(), "needs CUDA")
-    def test_baby_nccl(self) -> None:
+    @skipUnless(torch.cuda.device_count() >= 2, "need two CUDA devices")
+    def test_baby_nccl_2gpu(self) -> None:
         store = TCPStore(
             host_name="localhost", port=0, is_master=True, wait_for_workers=False
         )


### PR DESCRIPTION
CI Fixes:
* Centos 7 rust is too old so we need to use rustup to build with a newer version of rust.
* Our current GPU runner only has one GPU so we need to check # of gpus when running tests that require more