### PR TITLE
dashboard: show quorum status, age, old replicas

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ axum = "0.7.7"
 gethostname = "0.5.0"
 log = "0.4.22"
 prost = "0.13.3"
+prost-types = "0.13.3"
 pyo3 = {version="0.22.3", features = ["extension-module"]}
 slog = "2.7.0"
 slog-stdlog = "4.1.1"

--- a/proto/torchft.proto
+++ b/proto/torchft.proto
@@ -7,6 +7,8 @@
 syntax = "proto3";
 package torchft;
 
+import "google/protobuf/timestamp.proto";
+
 message RaftMessageRequest {
     // Request message contains the serialized Raft proto message.
     bytes message = 1;
@@ -43,6 +45,7 @@ message QuorumMember {
 message Quorum {
     int64 quorum_id = 1;
     repeated QuorumMember participants = 2;
+    google.protobuf.Timestamp created = 3;
 }
 
 message LighthouseQuorumRequest {

--- a/templates/index.html
+++ b/templates/index.html
@@ -40,6 +40,9 @@
     padding: 10px;
     border: 1px solid #333;
   }
+  .member.recovering {
+    background-color: orange;
+  }
   .heartbeat.old {
     color: red;
   }

--- a/templates/status.html
+++ b/templates/status.html
@@ -1,16 +1,21 @@
 <h2>Quorum Status</h2>
 
-Current quorum_id: {{quorum_id}}
+Current quorum_id: {{quorum_id}} <br>
+Next quorum status: {{quorum_status}}
 
 <h3>Previous Quorum</h3>
 {% if let Some(prev_quorum) = prev_quorum %}
 
-Previous quorum id: {{prev_quorum.quorum_id}}
+Previous quorum id: {{prev_quorum.quorum_id}} <br>
+Quorum age:
+{{SystemTime::try_from(prev_quorum.created.unwrap()).unwrap().elapsed().unwrap().as_secs_f64()}}s
 
 <div>
 {% for member in prev_quorum.participants %}
 
-<div class="member">
+<div class="member
+ {% if member.step != max_step %}recovering{% endif %}
+">
   <b>{{ member.replica_id }}</b> <br/>
   Step: {{ member.step }} <br/>
   Manager: {{ member.address }} <br/>
@@ -33,7 +38,9 @@ Previous quorum id: {{prev_quorum.quorum_id}}
 {% for replica_id in heartbeats.keys() %}
 
   {% let age = heartbeats[replica_id].elapsed().as_secs_f64() %}
-  <li class="heartbeat {% if heartbeats[replica_id].lt(old_age_threshold) %}old{%endif%}">
+  <li class="heartbeat
+    {% if heartbeats[replica_id].lt(old_age_threshold) %}old{%endif%}
+  ">
     {{ replica_id }}: seen {{ age }}s ago
   </li>
 


### PR DESCRIPTION
Dashboard updates to show the current quorum status, the age and highlight recovering workers.

Test plan:

![20241109_12h50m38s_grim](https://github.com/user-attachments/assets/33190de8-76c2-4a37-ae13-590c59bc1193)

Run lighthouse + two train_ddp workers