### PR TITLE
train, manager, dashboard: show world size on dashboard, manual replica_id, convergence tweaks

### DIFF
--- a/proto/torchft.proto
+++ b/proto/torchft.proto
@@ -40,6 +40,7 @@ message QuorumMember {
     string address = 2;
     string store_address = 3;
     int64 step = 4;
+    uint64 world_size = 5;
 }
 
 message Quorum {

--- a/src/lighthouse.rs
+++ b/src/lighthouse.rs
@@ -463,6 +463,7 @@ mod tests {
                         address: "".to_string(),
                         store_address: "".to_string(),
                         step: 1,
+                        world_size: 1,
                     },
                 },
             );
@@ -495,6 +496,7 @@ mod tests {
                         address: "".to_string(),
                         store_address: "".to_string(),
                         step: 1,
+                        world_size: 1,
                     },
                 },
             );
@@ -511,6 +513,7 @@ mod tests {
                     address: "".to_string(),
                     store_address: "".to_string(),
                     step: 1,
+                    world_size: 1,
                 }],
                 created: Some(SystemTime::now().into()),
             });
@@ -550,6 +553,7 @@ mod tests {
                     address: "".to_string(),
                     store_address: "".to_string(),
                     step: 10,
+                    world_size: 1,
                 }),
             });
 
@@ -568,12 +572,14 @@ mod tests {
             address: "".to_string(),
             store_address: "".to_string(),
             step: 1,
+            world_size: 1,
         }];
         let b = vec![QuorumMember {
             replica_id: "1".to_string(),
             address: "changed".to_string(),
             store_address: "changed".to_string(),
             step: 1000,
+            world_size: 1,
         }];
 
         // replica_id is the same
@@ -584,6 +590,7 @@ mod tests {
             address: "".to_string(),
             store_address: "".to_string(),
             step: 1,
+            world_size: 1,
         }];
         // replica_id changed
         assert!(quorum_changed(&a, &c));

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -192,6 +192,7 @@ impl ManagerService for Arc<Manager> {
                         address: self.address.clone(),
                         store_address: self.store_address.clone(),
                         step: req.step,
+                        world_size: self.world_size,
                     }),
                 });
 

--- a/templates/status.html
+++ b/templates/status.html
@@ -19,7 +19,8 @@ Quorum age:
   <b>{{ member.replica_id }}</b> <br/>
   Step: {{ member.step }} <br/>
   Manager: {{ member.address }} <br/>
-  TCPStore: {{ member.store_address }}
+  TCPStore: {{ member.store_address }} <br/>
+  World size: {{ member.world_size }} <br/>
 
   <button hx-post="/replica/{{member.replica_id}}/kill"
           hx-trigger="click">

--- a/torchft/manager.py
+++ b/torchft/manager.py
@@ -49,6 +49,7 @@ class Manager:
         store_addr: Optional[str] = None,
         store_port: Optional[int] = None,
         lighthouse_addr: Optional[str] = None,
+        replica_id: Optional[str] = None,
     ) -> None:
         """
         Args:
@@ -62,7 +63,8 @@ class Manager:
             world_size: the replica group local world size
             store_addr: TCPStore address for this replica group
             store_port: TCPStore port for this replica group
-            ligthouse_addr: if rank==0, the address of the lighthouse server
+            lighthouse_addr: if rank==0, the address of the lighthouse server
+            replica_id: if rank==0, the replica_id for this group
         """
         self._load_state_dict = load_state_dict
         self._state_dict = state_dict
@@ -99,7 +101,8 @@ class Manager:
             bind = f"[::]:{port}"
             lighthouse_addr = lighthouse_addr or os.environ["TORCHFT_LIGHTHOUSE"]
 
-            replica_id = str(uuid.uuid4())
+            if replica_id is None:
+                replica_id = str(uuid.uuid4())
             # pyre-fixme[16]: can't find rust module
             self._manager = _Manager(
                 replica_id=replica_id,


### PR DESCRIPTION
We allow setting a manual replica_id so the workers aren't continuously being recreated.

World size now shows on dashboard for convenience.

Verified loss converges

Test plan:

Lighthouse + 2 train_ddp

![20241109_13h13m55s_grim](https://github.com/user-attachments/assets/d911c772-67ef-4cb7-8ce1-379749fd4682)
 