### PR TITLE
Specifiy the devices when registering the backend to avoid warnings

### DIFF
--- a/torchft/process_group.py
+++ b/torchft/process_group.py
@@ -124,7 +124,11 @@ class ProcessGroup(BaseProcessGroup):
         ) -> ProcessGroup:
             return self
 
-        dist.Backend.register_backend(group_name, create_pg)
+        if torch.cuda.is_available():
+            devices = ["cuda", "cpu"]
+        else:
+            devices = ["cpu"]
+        dist.Backend.register_backend(group_name, create_pg, devices=devices)
 
         return dist.new_group(
             ranks=[dist.get_rank()],


### PR DESCRIPTION
If we don't specify the devices, c10d will print out the warning when we create a new group.

pytest process_group_test.py