### PR TITLE
process_group: wrapper updates and ErrorSwallowingProcessGroup

### DIFF
--- a/torchft/manager.py
+++ b/torchft/manager.py
@@ -252,8 +252,7 @@ class Manager:
             default: the default value to complete the Future with if an error occurs
         """
 
-        # schedule error handling and grad normalization as a continuation
-        # on the Future
+        # schedule error handling as a continuation on the Future
         def callback(
             fut: torch.futures.Future[List[torch.Tensor]],
         ) -> torch.futures.Future[torch.Tensor]:


### PR DESCRIPTION
This introduces the beginnings of a specialized error swallowing process group wrapper. This is intended to be the basis of writing a `ManagedProcessGroup` that can be transparently used with libraries like FSDPv2/DeviceMesh that directly consume a process group.

This currently only wraps `allreduce` and not the other methods.

Test plan:

```
pytest
```