### PR TITLE
manager: added E2E tests and support getting lighthouse and manager addresses

### DIFF
--- a/src/bin/lighthouse.rs
+++ b/src/bin/lighthouse.rs
@@ -17,7 +17,7 @@ async fn main() {
         .unwrap();
 
     let opt = LighthouseOpt::from_args();
-    let lighthouse = Lighthouse::new(opt);
+    let lighthouse = Lighthouse::new(opt).await.unwrap();
 
     lighthouse.run().await.unwrap();
 }


### PR DESCRIPTION
This adds a basic Manager E2E test that spins up a lighthouse server to test with.

This also refactor the code so it's possible to bind lighthouse and manager to port 0 and fetch the port afterwards. This makes writing tests easier as they instead grab the first ephemeral port rather than a well known port.

Test plan:

```
cargo fmt
cargo test
```