### PR TITLE
pyre strict

### DIFF
--- a/.pyre_configuration
+++ b/.pyre_configuration
@@ -1,4 +1,5 @@
 {
+  "strict": true,
   "site_package_search_strategy": "pep561",
   "source_directories": [
     {

--- a/torchft/data.py
+++ b/torchft/data.py
@@ -20,6 +20,7 @@ import torch.distributed as dist
 from torch.utils import data
 
 
+# pyre-fixme[24]: expected generic parameter
 class DistributedSampler(data.distributed.DistributedSampler):
     """
     DistributedSampler extends the standard PyTorch DistributedSampler with a
@@ -49,7 +50,7 @@ class DistributedSampler(data.distributed.DistributedSampler):
         num_replica_groups: int,
         rank: Optional[int] = None,
         num_replicas: Optional[int] = None,
-        **kwargs,
+        **kwargs: object,
     ) -> None:
         """
         Args:
@@ -64,12 +65,13 @@ class DistributedSampler(data.distributed.DistributedSampler):
         if num_replicas is None:
             num_replicas = dist.get_world_size()
 
-        self.global_rank = rank + num_replicas * replica_group
-        self.global_world_size = num_replicas * num_replica_groups
+        self.global_rank: int = rank + num_replicas * replica_group
+        self.global_world_size: int = num_replicas * num_replica_groups
 
         super().__init__(
             dataset,
             rank=self.global_rank,
             num_replicas=self.global_world_size,
+            # pyre-fixme[6]: got object
             **kwargs,
         )

--- a/torchft/ddp_test.py
+++ b/torchft/ddp_test.py
@@ -18,7 +18,7 @@ from torchft.process_group import ProcessGroupBabyGloo, ProcessGroupGloo
 
 
 class TestDDP(TestCase):
-    def test_pure_ddp(self):
+    def test_pure_ddp(self) -> None:
         manager = create_autospec(Manager)
 
         m = nn.Linear(3, 4)
@@ -34,7 +34,7 @@ class TestDDP(TestCase):
 
         self.assertEqual(manager.allreduce_grad.call_count, len(list(m.parameters())))
 
-    def test_ddp(self):
+    def test_ddp(self) -> None:
         manager = create_autospec(Manager)
 
         call_count = 0

--- a/torchft/http.py
+++ b/torchft/http.py
@@ -3,5 +3,5 @@ from http.server import ThreadingHTTPServer
 
 
 class _IPv6HTTPServer(ThreadingHTTPServer):
-    address_family = socket.AF_INET6
-    request_queue_size = 1024
+    address_family: socket.AddressFamily = socket.AF_INET6
+    request_queue_size: int = 1024

--- a/torchft/manager_test.py
+++ b/torchft/manager_test.py
@@ -51,12 +51,12 @@ class TestManager(TestCase):
         return manager
 
     @patch("torchft.manager.ManagerClient", autospec=True)
-    def test_manager(self, client_mock) -> None:
+    def test_manager(self, client_mock: MagicMock) -> None:
         manager = self._create_manager()
         self.assertEqual(client_mock.call_count, 1)
 
     @patch("torchft.manager.ManagerClient", autospec=True)
-    def test_state_dict(self, client_mock) -> None:
+    def test_state_dict(self, client_mock: MagicMock) -> None:
         manager = self._create_manager()
 
         state_dict = manager.state_dict()
@@ -78,7 +78,7 @@ class TestManager(TestCase):
         self.assertEqual(manager.batches_committed(), 2345)
 
     @patch("torchft.manager.ManagerClient", autospec=True)
-    def test_quorum_happy(self, client_mock) -> None:
+    def test_quorum_happy(self, client_mock: MagicMock) -> None:
         manager = self._create_manager()
         client_mock().should_commit = lambda rank, step, should_commit: should_commit
 
@@ -113,7 +113,7 @@ class TestManager(TestCase):
         self.assertEqual(manager.batches_committed(), 2)
 
     @patch("torchft.manager.ManagerClient", autospec=True)
-    def test_quorum_heal_sync(self, client_mock) -> None:
+    def test_quorum_heal_sync(self, client_mock: MagicMock) -> None:
         manager = self._create_manager(use_async_quorum=False)
         client_mock().should_commit = lambda rank, step, should_commit: should_commit
 
@@ -153,7 +153,9 @@ class TestManager(TestCase):
         self.assertEqual(self.load_state_dict.call_count, 1)
 
     @patch("torchft.manager.ManagerClient", autospec=True)
-    def test_quorum_heal_async_not_enough_participants(self, client_mock) -> None:
+    def test_quorum_heal_async_not_enough_participants(
+        self, client_mock: MagicMock
+    ) -> None:
         manager = self._create_manager(use_async_quorum=True, min_replica_size=2)
         client_mock().should_commit = lambda rank, step, should_commit: should_commit
 
@@ -177,6 +179,7 @@ class TestManager(TestCase):
         self.assertEqual(manager._step, 0)
 
         manager.step()
+        assert manager._quorum_future is not None
         manager._quorum_future.result()
         self.assertTrue(manager._healing)
         self.assertFalse(manager.is_participating())
@@ -204,7 +207,7 @@ class TestManager(TestCase):
         self.assertEqual(manager.batches_committed(), 0)
 
     @patch("torchft.manager.ManagerClient", autospec=True)
-    def test_quorum_heal_async_zero_grad(self, client_mock) -> None:
+    def test_quorum_heal_async_zero_grad(self, client_mock: MagicMock) -> None:
         manager = self._create_manager(use_async_quorum=True, min_replica_size=1)
         client_mock().should_commit = lambda rank, step, should_commit: should_commit
 
@@ -228,6 +231,7 @@ class TestManager(TestCase):
         self.assertEqual(manager._step, 0)
 
         manager.step()
+        assert manager._quorum_future is not None
         manager._quorum_future.result()
         self.assertTrue(manager._healing)
 
@@ -253,7 +257,7 @@ class TestManager(TestCase):
         self.assertEqual(manager.batches_committed(), 1)
 
     @patch("torchft.manager.ManagerClient", autospec=True)
-    def test_allreduce_error(self, client_mock) -> None:
+    def test_allreduce_error(self, client_mock: MagicMock) -> None:
         manager = self._create_manager()
         client_mock().should_commit = lambda rank, step, should_commit: should_commit
 
@@ -338,7 +342,7 @@ class TestManager(TestCase):
         self.assertTrue(manager.should_commit())
 
     @patch("torchft.manager.ManagerClient", autospec=True)
-    def test_quorum_fixed_world_size(self, client_mock) -> None:
+    def test_quorum_fixed_world_size(self, client_mock: MagicMock) -> None:
         # test active and spares
         for rank in [1, 2]:
             manager = self._create_manager(
@@ -375,7 +379,7 @@ class TestManager(TestCase):
             self.assertEqual(manager.batches_committed(), 2)
 
     @patch("torchft.manager.ManagerClient", autospec=True)
-    def test_manager_report_error(self, client_mock) -> None:
+    def test_manager_report_error(self, client_mock: MagicMock) -> None:
         manager = self._create_manager()
 
         self.assertFalse(manager.errored())
@@ -383,7 +387,7 @@ class TestManager(TestCase):
         self.assertTrue(manager.errored())
 
     @patch("torchft.manager.ManagerClient", autospec=True)
-    def test_manager_wrap_future(self, client_mock) -> None:
+    def test_manager_wrap_future(self, client_mock: MagicMock) -> None:
         manager = self._create_manager()
 
         self.assertFalse(manager.errored())
@@ -398,7 +402,7 @@ class TestManager(TestCase):
         self.assertEqual(manager._pending_work, [wrapped_fut])
 
     @patch("torchft.manager.ManagerClient", autospec=True)
-    def test_manager_numerics(self, client_mock) -> None:
+    def test_manager_numerics(self, client_mock: MagicMock) -> None:
         manager = self._create_manager()
 
         manager._quorum_future = MagicMock()

--- a/torchft/process_group_test.py
+++ b/torchft/process_group_test.py
@@ -62,6 +62,7 @@ class ProcessGroupTest(TestCase):
         m = torch.nn.parallel.DistributedDataParallel(m, process_group=pg)
         m(torch.rand(2, 3))
 
+    # pyre-fixme[56]: Pyre was not able to infer the type of argument
     @skipUnless(torch.cuda.is_available(), "needs CUDA")
     def test_nccl(self) -> None:
         store = TCPStore(
@@ -128,13 +129,14 @@ class ProcessGroupTest(TestCase):
         m = torch.nn.parallel.DistributedDataParallel(m, process_group=pg)
         m(torch.rand(2, 3))
 
+    # pyre-fixme[56]: Pyre was not able to infer the type of argument
     @skipUnless(torch.cuda.device_count() >= 2, "need two CUDA devices")
     def test_baby_nccl_2gpu(self) -> None:
         store = TCPStore(
             host_name="localhost", port=0, is_master=True, wait_for_workers=False
         )
 
-        store_addr = f"localhost:{store.port}/prefix"
+        store_addr: str = f"localhost:{store.port}/prefix"
 
         def run(rank: int) -> Tuple[torch.Tensor, Work]:
             a = ProcessGroupBabyNCCL()


### PR DESCRIPTION
This enables pyre-strict for all of torchft and fixes all type errors.

Test plan:

```
pyre
lintrunner
pytest
```