### PR TITLE
manager_integ_tests: added multi rank recovery

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,8 @@ dependencies = [
 dev = [
     "pytest",
     "black",
-    "pyre-check"
+    "pyre-check",
+    "parameterized"
 ]
 
 [tool.maturin]

--- a/torchft/ddp.py
+++ b/torchft/ddp.py
@@ -52,6 +52,12 @@ class DistributedDataParallel(parallel.DistributedDataParallel):
         super().__init__(
             module,
             process_group=pg,
+            # HACK: This forces the reducer to never rebuild buckets.
+            # The reducer normally rebuilds the buckets after the first training
+            # step which can improve performance but is incompatible with
+            # torchft as it will cause the buckets to diverge for recovering
+            # replicas.
+            find_unused_parameters=True,
             # pyre-fixme[6]: got object
             **kwargs,
         )


### PR DESCRIPTION
This adds a multi rank recovery integration test

It also refactors the logging in Manager to be a bit more understandable when multiple ranks/replica logs are combined

Test plan:

```
pytest
```