### PR TITLE
manager: support multiple calls to start_quorum and conditional healing

### DIFF
--- a/torchft/optim.py
+++ b/torchft/optim.py
@@ -45,7 +45,7 @@ class OptimizerWrapper(Optimizer):
         return self.optim.state_dict()
 
     def zero_grad(self, set_to_none: bool = True) -> None:
-        self.manager.start_step()
+        self.manager.start_quorum()
         self.optim.zero_grad(set_to_none)
 
     def step(self, closure: Optional[object] = None) -> None:

--- a/torchft/optim_test.py
+++ b/torchft/optim_test.py
@@ -32,7 +32,7 @@ class TestOptim(TestCase):
         optim.load_state_dict(optim.state_dict())
 
         optim.zero_grad()
-        self.assertEqual(manager.start_step.call_count, 1)
+        self.assertEqual(manager.start_quorum.call_count, 1)
 
         manager.should_commit.return_value = True
         optim.step()


### PR DESCRIPTION
This renames `start_step` to `start_quorum` as we can now call it multiple times. The manager step is now only changed during `should_commit`. We also now support getting a quorum without healing.

`allow_heal` must be the same on all workers (TBD -- this may be hacky hmm since we don't know what state the workers are in.

This is work towards #39

Test plan:

```
pytest torchft/manager_test.py torchft/manager_integ_test.py
```