### PR TITLE
chore: compile -> compile_protos

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -7,6 +7,6 @@
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     tonic_build::configure()
         .protoc_arg("--experimental_allow_proto3_optional")
-        .compile(&["proto/torchft.proto"], &["proto"])?;
+        .compile_protos(&["proto/torchft.proto"], &["proto"])?;
     Ok(())
 }


### PR DESCRIPTION
There's a warning about it. Goes away with this change
```
warning: use of deprecated method `tonic_build::Builder::compile`: renamed to `compile_protos()`
  --> build.rs:10:10
   |
10 |         .compile(&["proto/torchft.proto"], &["proto"])?;
   |          ^^^^^^^
   |
   = note: `#[warn(deprecated)]` on by default

warning: `torchft` (build script) generated 1 warning
```