### PR TITLE
manager_integ_tests: added LocalSGD integration test

### DIFF
--- a/torchft/local_sgd.py
+++ b/torchft/local_sgd.py
@@ -178,7 +178,7 @@ class LocalSGD(nn.Module):
 
         for p in self._model.parameters():
             # TODO: bucketize parameters
-            works.append(self._manager.allreduce(p))
+            works.append(self._manager.allreduce(p.data.detach()))
 
         for work in works:
             work.wait()


### PR DESCRIPTION
This adds an integration test for LocalSGD that tests one of the replicas crashing and recovering.

This runs for 8 steps with `sync_every=2` and 4 manager steps.

This mostly is refactoring the integration tests into a more flexible `Runner` class and adds a new `local_sgd_train_loop`. It does fix one bug in LocalSGD where we don't detach the gradient before running the all reduce.

cc @Jackmin801 

Test plan:

```
pytest torchft/manager_integ_test.py -k local_sgd -s -x
```